### PR TITLE
Update config_reg019-001.sh

### DIFF
--- a/config_reg019-001.sh
+++ b/config_reg019-001.sh
@@ -3,4 +3,4 @@ NIC2=ens1f1
 VF=ens1f2
 VF1=$VF
 VF2=ens1f3
-REP=ens1f0_0
+REP=eth0


### PR DESCRIPTION
Using centos7.2 we dont have udev rule for representor naming so the rep name is eth0.

Signed-off-by: ziyadatiyyeh <ziyadat@mellanox.com>