### PR TITLE
config_reg019-001.sh: Use rep names ens1f0_0 and ens1f0_1

### DIFF
--- a/config_reg019-001.sh
+++ b/config_reg019-001.sh
@@ -3,5 +3,5 @@ NIC2=ens1f1
 VF=ens1f2
 VF1=$VF
 VF2=ens1f3
-REP=eth0
-REP2=eth1
+REP=ens1f0_0
+REP2=ens1f0_1


### PR DESCRIPTION
centos7.2 is using the udev rule to update representor names so the names are ens1f0_0 and ens1f0_1.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>