### PR TITLE
test-eswitch-add-in-mode1-del-in-mode2.sh: Fix REP dev name issue

### DIFF
--- a/test-eswitch-add-in-mode1-del-in-mode2.sh
+++ b/test-eswitch-add-in-mode1-del-in-mode2.sh
@@ -59,7 +59,7 @@ function add_vxlan_rule() {
                         enc_key_id 100 \
                         enc_dst_port 4789 \
                 action tunnel_key unset \
-                action mirred egress redirect dev ${NIC}_0 && success || err "Failed"
+                action mirred egress redirect dev ${REP} && success || err "Failed"
 }
 
 


### PR DESCRIPTION
The rule added for vxlan is added to the REP device, though instead of
using the device name it used the NIC and inferred the rep name. This
method is not compatible with platforms that name the representors
according to a different format, and therefore the REP device name is
taken from the configuration script.

Signed-off-by: Gavi Teitz <gavi@mellanox.com>