### PR TITLE
test-vf-vf-fwd.sh: Increase default rounds to 200 and timeout to 2000

### DIFF
--- a/test-vf-vf-fwd.sh
+++ b/test-vf-vf-fwd.sh
@@ -17,8 +17,8 @@ test -z "$REP2" && fail "Missing REP2"
 IP1="7.7.7.1"
 IP2="7.7.7.2"
 
-TIMEOUT=${TIMEOUT:-120}
-ROUNDS=${ROUNDS:-10}
+TIMEOUT=${TIMEOUT:-2000}
+ROUNDS=${ROUNDS:-200}
 MULTIPATH=${MULTIPATH:-0}
 
 function cleanup() {


### PR DESCRIPTION
With 200 rounds we ensure reproducing issue "1223798" since it happens
sometimes after 100 round.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>