### PR TITLE
test-ovs-vxlan-in-ns-hw.sh: add vf's bind

### DIFF
--- a/test-ovs-vxlan-in-ns-hw.sh
+++ b/test-ovs-vxlan-in-ns-hw.sh
@@ -32,7 +32,7 @@ function cleanup() {
 }
 
 cleanup
-
+bind_vfs $NIC
 
 for i in $vm1_port $vm1_port_rep $vm2_port $vm2_port_rep ; do
     test -e /sys/class/net/$i || fail "Cannot find interface $i"


### PR DESCRIPTION
Call bind_vfs to bind vf's before starting the test.

Signed-off-by: Ziyad Atiyyeh <ziyadat@mellanox.com>