### PR TITLE
Updated all reload modules related tests for backport

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -438,6 +438,22 @@ function start_clean_openvswitch() {
     del_all_bridges
 }
 
+function reload_modules() {
+    if [ "$devlink_compat" = 1 ]; then
+        service openibd force-restart
+    else
+        modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
+        modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
+    fi
+
+    a=`journalctl -n200 | grep KASAN || true`
+    if [ "$a" != "" ]; then
+        fail "Detected KASAN in journalctl"
+    fi
+    set_macs
+    echo "reload modules done"
+}
+
 function eval2() {
     local err
     eval $@

--- a/test-eswitch-add-flows-during-reload.sh
+++ b/test-eswitch-add-flows-during-reload.sh
@@ -44,22 +44,6 @@ function add_rules() {
     done
 }
 
-function reload_modules() {
-    if [ "$devlink_compat" = 1 ]; then
-        service openibd force-restart
-    else
-        modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
-        modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
-    fi
-
-    a=`journalctl -n200 | grep KASAN || true`
-    if [ "$a" != "" ]; then
-        fail "Detected KASAN in journalctl"
-    fi
-    set_macs
-    echo "reload modules done"
-}
-
 
 title "test reload modules"
 start_check_syndrome

--- a/test-eswitch-del-flows-during-reload.sh
+++ b/test-eswitch-del-flows-during-reload.sh
@@ -53,8 +53,13 @@ function del_rules() {
 }
 
 function reload_modules() {
-    modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
-    modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
+    if [ "$devlink_compat" = 1 ]; then
+	service openibd force-restart
+    else
+        modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
+        modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
+    fi
+
     a=`journalctl -n200 | grep KASAN || true`
     if [ "$a" != "" ]; then
         fail "Detected KASAN in journalctl"

--- a/test-eswitch-del-flows-during-reload.sh
+++ b/test-eswitch-del-flows-during-reload.sh
@@ -52,21 +52,6 @@ function del_rules() {
     done
 }
 
-function reload_modules() {
-    if [ "$devlink_compat" = 1 ]; then
-	service openibd force-restart
-    else
-        modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
-        modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
-    fi
-
-    a=`journalctl -n200 | grep KASAN || true`
-    if [ "$a" != "" ]; then
-        fail "Detected KASAN in journalctl"
-    fi
-    set_macs
-    echo "reload modules done"
-}
 
 title "test reload modules"
 reload_modules &

--- a/test-reload-modules-different-state.sh
+++ b/test-reload-modules-different-state.sh
@@ -50,8 +50,14 @@ function add_tc_rule_to_pf() {
 
 function reload_mlx5() {
     title "test reload modules"
-    modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
-    modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
+
+    if [ "$devlink_compat" = 1 ]; then
+	service openibd force-restart
+    else
+        modprobe -r mlx5_ib mlx5_core devlink || fail "Failed to unload modules"
+        modprobe -a devlink mlx5_core mlx5_ib || fail "Failed to load modules"
+    fi
+
     set_macs
     check_kasan
 }
@@ -65,6 +71,14 @@ function testA() {
 
 function testB() {
     title "TEST B - switchdev mode with tc rules"
+
+    if [ "$devlink_compat" = 1 ]; then
+       # not relevant in backport as mlx5_core is dependent on cls_flower
+       # and we cannot remove cls_flower when there are rules.
+       echo "Test not relevant in backport"
+       return
+    fi
+
     unbind_vfs
     switch_mode_switchdev
     echo "look for $REP"
@@ -79,6 +93,14 @@ function testB() {
 
 function testC() {
     title "TEST C - legacy mode with tc rules"
+
+    if [ "$devlink_compat" = 1 ]; then
+       # not relevant in backport as mlx5_core is dependent on cls_flower
+       # and we cannot remove cls_flower when there are rules.
+       echo "Test not relevant in backport"
+       return
+    fi
+
     unbind_vfs
     switch_mode_legacy
     add_tc_rule_to_pf


### PR DESCRIPTION
Updates for when using asap mlnx ofed machine in tests:
test-ecmp-devlink-multipath.sh
test-eswitch-add-flows-during-reload.sh
test-eswitch-add-flows-during-reload.sh
test-reload-modules-different-state.sh