### PR TITLE
test-ecmp-lag-affinity: disable multipath before enabling

### DIFF
--- a/test-ecmp-lag-affinity.sh
+++ b/test-ecmp-lag-affinity.sh
@@ -40,6 +40,7 @@ function test_lag_affinity() {
     enable_sriov
     unbind_vfs $NIC
     unbind_vfs $NIC2
+    disable_multipath
     enable_multipath || err "Failed to enable multipath"
     ifconfig $NIC up
     ifconfig $NIC2 up


### PR DESCRIPTION
Needed for getting the lag map state in the log.

Signed-off-by: Shahar Klein <shahark@mellanox.com>