### PR TITLE
test-ovs-icmp-frag.sh: Don't check offloaded rules if testing for offload is disabled

### DIFF
--- a/test-ovs-icmp-frag.sh
+++ b/test-ovs-icmp-frag.sh
@@ -53,8 +53,13 @@ ovs-vsctl add-port brv-1 $REP2
 
 function check_offloaded_rules() {
     local count=$1
-    title " - check for $count offloaded rules"
-    RES="ovs_dpctl_dump_flows | grep 0x0800 | grep -v drop"
+    if [ "$TEST_OFFLOAD" = 1 ]; then
+        title " - check for $count offloaded rules"
+        RES="ovs_dpctl_dump_flows | grep 0x0800 | grep -v drop"
+    else
+        title " - check for $count rules"
+        RES="ovs-dpctl dump-flows | grep 0x0800 | grep -v drop"
+    fi
     eval $RES
     RES=`eval $RES | wc -l`
     if (( RES == $count )); then success; else err; fi


### PR DESCRIPTION

Signed-off-by: Jianbo Liu <jianbol@mellanox.com>